### PR TITLE
rewrited file writing functions

### DIFF
--- a/lib/generators/graphql_add_fields/graphql_add_fields_generator.rb
+++ b/lib/generators/graphql_add_fields/graphql_add_fields_generator.rb
@@ -245,10 +245,10 @@ t.#{@id_db_type} :#{resource.underscore.singularize}_id
     file_name = "app/models/#{model.underscore.singularize}.rb"
     return if !File.exist?(file_name) || File.read(file_name).include?(line)
 
-    line_count = `wc -l "#{file_name}"`.strip.split(' ')[0].to_i
-
+    file = open(file_name)
+    line_count = file.readlines.size
     line_nb = 0
-    File.open(file_name).each do |l|
+    file.each do |l|
       line_nb += 1
       break if l.include?('ApplicationRecord')
     end

--- a/lib/generators/graphql_all_connections/graphql_all_connections_generator.rb
+++ b/lib/generators/graphql_all_connections/graphql_all_connections_generator.rb
@@ -8,6 +8,7 @@ class GraphqlAllConnectionsGenerator < Rails::Generators::NamedBase
   end
 
   def generate_connection(dir, resource)
+    FileUtils.mkdir_p(dir) unless File.directory?(dir)
     File.write(
       "#{dir}/connection.rb",
       <<~STRING

--- a/lib/generators/graphql_mutations/graphql_mutations_generator.rb
+++ b/lib/generators/graphql_mutations/graphql_mutations_generator.rb
@@ -3,7 +3,7 @@ class GraphqlMutationsGenerator < Rails::Generators::NamedBase
   def generate
     resource = file_name.underscore.singularize
     dir = "app/graphql/#{resource.pluralize}/mutations"
-    system("mkdir -p #{dir}")
+    FileUtils.mkdir_p(dir) unless File.directory?(dir)
     generate_create_mutation(dir, resource)
     generate_update_mutation(dir, resource)
     generate_destroy_mutation(dir, resource)

--- a/lib/generators/graphql_rails_api/install_generator.rb
+++ b/lib/generators/graphql_rails_api/install_generator.rb
@@ -8,8 +8,10 @@ module GraphqlRailsApi
 
     def generate_files
       @app_name = File.basename(Rails.root.to_s).underscore
-      system('mkdir -p app/graphql/')
-
+      
+      folder = 'app/graphql/'
+      FileUtils.mkdir_p(folder) unless File.directory?(folder)
+       
       write_uuid_extensions_migration
 
       write_service

--- a/lib/generators/graphql_resource/graphql_resource_generator.rb
+++ b/lib/generators/graphql_resource/graphql_resource_generator.rb
@@ -103,7 +103,7 @@ class GraphqlResourceGenerator < Rails::Generators::NamedBase
   end
 
   def generate_basic_mutations(resource)
-    system("mkdir -p #{@mutations_directory}")
+    FileUtils.mkdir_p(@mutations_directory) unless File.directory?(@mutations_directory)
     system("rails generate graphql_mutations #{resource}")
 
     # Graphql Input Type
@@ -126,7 +126,8 @@ class GraphqlResourceGenerator < Rails::Generators::NamedBase
   end
 
   def generate_graphql_input_type(resource)
-    system("mkdir -p #{@mutations_directory}")
+    FileUtils.mkdir_p(@mutations_directory) unless File.directory?(@mutations_directory)
+
     File.write(
       "#{@mutations_directory}/input_type.rb",
       <<~STRING
@@ -241,6 +242,9 @@ class GraphqlResourceGenerator < Rails::Generators::NamedBase
   end
 
   def generate_service(resource)
+     
+    FileUtils.mkdir_p("app/graphql/#{resource.pluralize}/") unless File.directory?("app/graphql/#{resource.pluralize}/")
+     
     File.write(
       "app/graphql/#{resource.pluralize}/service.rb",
       <<~STRING
@@ -308,13 +312,13 @@ t.#{@id_db_type} :#{resource.underscore.singularize}_id
   end
 
   def add_to_model(model, line)
-    file_name = "app/models/#{model.underscore.singularize}.rb"
+    file_name = File.join("app","models","#{model.underscore.singularize}.rb")
     return if !File.exist?(file_name) || File.read(file_name).include?(line)
 
-    line_count = `wc -l "#{file_name}"`.strip.split(' ')[0].to_i
-
+    file = open(file_name)
+    line_count = file.readlines.size
     line_nb = 0
-    File.open(file_name).each do |l|
+    file.each do |l|
       line_nb += 1
       break if l.include?('ApplicationRecord')
     end


### PR DESCRIPTION
- `file.readlines.size` instead of Unix` wc -l ` to add windows compatibility. (Works on Windows 10)
- `FileUtils.mkdir_p(dir)` instead of `system("mkdir -p #{dir}")`
