### PR TITLE
Release v0.9.0

### DIFF
--- a/lib/graphql/rails/api/version.rb
+++ b/lib/graphql/rails/api/version.rb
@@ -1,7 +1,7 @@
 module Graphql
   module Rails
     module Api
-      VERSION = '0.8.1'.freeze
+      VERSION = '0.9.0'.freeze
     end
   end
 end


### PR DESCRIPTION
## Que fait cette PR?

- Mets a jour la gem pour utiliser rails 7.

## Pourquoi ce changement?

Préparation à la mise de jour de comptacrypto avec rails 7 afin d'utiliser les nouvelles features ([module encryption](https://guides.rubyonrails.org/v7.0.0/active_record_encryption.html))